### PR TITLE
Fixing quick try bad request error (api request from blocked host) #patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Made with ❤️ in London
 
 ## Give it a quick try
 ```
-docker run -p 80:80 vanalmsick/workout_challenge
+docker run -p 80:80 -e ALLOW_ALL_HOSTS=true vanalmsick/workout_challenge
 ```
 
 ## Full Production Deployment
@@ -71,7 +71,7 @@ services:
       - TIME_ZONE=Europe/London
       - STRAVA_CLIENT_ID=000000
       - STRAVA_CLIENT_SECRET=<secret_key>
-      - REACT_APP_SENTRY_DSN=https://<PUBLIC_KEY>@<HOST>/<PROJECT_ID>
+      - SENTRY_DSN=https://<PUBLIC_KEY>@<HOST>/<PROJECT_ID>
       - EMAIL_HOST=smtp.gmail.com
       - EMAIL_PORT=465
       - EMAIL_HOST_USER=competition@yourdomain.com
@@ -117,12 +117,13 @@ docker compose -f /path/to/docker-compose.yml up
 | SECRET_KEY            | [a hard-coded string in code]       | Django's [SECRET_KEY](https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-SECRET_KEY) for cryptographic signing.                                                                                                                                                                                    |
 | TIME_ZONE             | "Europe/London"                     | Timezone for [Django](https://docs.djangoproject.com/en/5.2/ref/settings/#time-zone) and [Celery](https://docs.celeryq.dev/en/stable/userguide/configuration.html#timezone)                                                                                                                                     |
 | DEBUG                 | false                               | Django's DEBUG mode. If true, [CORS_ALLOW_ALL_ORIGINS](https://pypi.org/project/django-cors-headers/) will also be true and the [CACHE](https://docs.djangoproject.com/en/5.2/ref/settings/#caches) will use [Local Memory Cache](https://docs.djangoproject.com/en/5.2/ref/settings/#caches) instead of Redis. |
+| ALLOW_ALL_HOSTS       | false                               | For quick testing to not having to set HOSTS. Do not set to true in production but set HOSTS.                                                                                                                                                                                                                   |
 | POSTGRES_HOST         | None                                | If set to None, Django will use SQLite as database (might cause database lock errors in production), else this is the host url to the [Postgres database](https://hub.docker.com/_/postgres/).                                                                                                                  |
 | POSTGRES_DB           | "postgres"                          | Database name in [Postgres database](https://hub.docker.com/_/postgres/)                                                                                                                                                                                                                                        | 
 | POSTGRES_USER         | "postgres"                          | Database username in [Postgres database](https://hub.docker.com/_/postgres/)                                                                                                                                                                                                                                    | 
 | POSTGRES_PASSWORD     | ""                                  | Database password in [Postgres database](https://hub.docker.com/_/postgres/)                                                                                                                                                                                                                                    | 
-| REACT_APP_SENTRY_DSN  | None                                | If None no [Sentry.io](https://sentry.io/) error capturing, else please provide the project url https://<PUBLIC_KEY>@<HOST>/<PROJECT_ID>                                                                                                                                                                        | 
-| STRAVA_CLIENT_ID      | "1234321"                           | [Strava API](https://developers.strava.com) Client Id. Please see below how to get one.                                                                                                                                                                                                                         | 
+| SENTRY_DSN            | None                                | If None no [Sentry.io](https://sentry.io/) error capturing, else please provide the project url https://<PUBLIC_KEY>@<HOST>/<PROJECT_ID> *(In local development you might have to set REACT_APP_SENTRY_DSN instead)*                                                                                            | 
+| STRAVA_CLIENT_ID      | "1234321"                           | [Strava API](https://developers.strava.com) Client Id. Please see below how to get one. *(In local development you might have to set REACT_APP_STRAVA_CLIENT_ID instead)*                                                                                                                                       | 
 | STRAVA_CLIENT_SECRET  | "ReplaceWithClientSecret"           | [Strava API](https://developers.strava.com) Client Secret. Please see below how to get one.                                                                                                                                                                                                                     | 
 | STRAVA_LIMIT_15MIN    | 100                                 | [Strava API](https://developers.strava.com) Limit per 15min. 300 if part of developer program, else 100.                                                                                                                                                                                                        | 
 | STRAVA_LIMIT_DAY      | 1000                                | [Strava API](https://developers.strava.com) Limit per day. 3000 if part of developer program, else 1000.                                                                                                                                                                                                        | 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - TIME_ZONE=Europe/London
       - STRAVA_CLIENT_ID=000000
       - STRAVA_CLIENT_SECRET=<secret_key>
-      - REACT_APP_SENTRY_DSN=https://<PUBLIC_KEY>@<HOST>/<PROJECT_ID>
+      - SENTRY_DSN=https://<PUBLIC_KEY>@<HOST>/<PROJECT_ID>
       - EMAIL_HOST=smtp.gmail.com
       - EMAIL_PORT=465
       - EMAIL_HOST_USER=competition@yourdomain.com

--- a/src-backend/workout_challenge/settings.py
+++ b/src-backend/workout_challenge/settings.py
@@ -37,9 +37,9 @@ print(f'Debug modus is turned {"on" if DEBUG else "off"}')
 MAIN_HOST = os.environ.get("MAIN_HOST", "http://localhost")
 HOSTS = os.environ.get("HOSTS", "http://localhost,http://127.0.0.1").split(",")
 CSRF_TRUSTED_ORIGINS = HOSTS
-ALLOWED_HOSTS = [urlparse(url).netloc for url in HOSTS]
+ALLOWED_HOSTS = ['*'] if os.environ.get("ALLOW_ALL_HOSTS", "false").lower() == "true" else [urlparse(url).netloc for url in HOSTS]
 CORS_ALLOWED_ORIGINS = HOSTS
-CORS_ALLOW_ALL_ORIGINS = True if DEBUG else False
+CORS_ALLOW_ALL_ORIGINS = True if DEBUG or os.environ.get("ALLOW_ALL_HOSTS", "false").lower() == "true" else False
 CORS_ALLOW_CREDENTIALS = True
 
 
@@ -230,7 +230,7 @@ STRAVA_LIMIT_DAY = int(os.environ.get("STRAVA_LIMIT_DAY", 1000))
 
 
 # Sentry
-if (sentry_sdk_url := os.environ.get("REACT_APP_SENTRY_DSN", None)) is not None:
+if (sentry_sdk_url := os.environ.get("SENTRY_DSN", None)) is not None:
     sentry_sdk.init(
         dsn=sentry_sdk_url,
         environment="backend",

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -69,7 +69,7 @@ stopwaitsecs=20
 
 # Nginx proxy for React frontend and backend redirect to gunicorn running Django
 [program:nginx]
-command=sh -c 'echo "window.RUNTIME_CONFIG = { REACT_APP_SENTRY_DSN: \"${REACT_APP_SENTRY_DSN}\", REACT_APP_STRAVA_CLIENT_ID: \"${STRAVA_CLIENT_ID}\" };" > /usr/share/nginx/html/config.js && /usr/sbin/nginx -g "daemon off;"'
+command=sh -c 'echo "window.RUNTIME_CONFIG = { REACT_APP_SENTRY_DSN: \"${SENTRY_DSN}\", REACT_APP_STRAVA_CLIENT_ID: \"${STRAVA_CLIENT_ID}\" };" > /usr/share/nginx/html/config.js && /usr/sbin/nginx -g "daemon off;"'
 stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0


### PR DESCRIPTION
**Fixes:**
- #2 & #3 add ALLOW_ALL_HOSTS to avoid api requests being blocked on non-localhost quick tests
- rename env REACT_APP_SENTRY_DSN to SENTRY_DSN